### PR TITLE
Note that only current term will be returned by default for /schedule

### DIFF
--- a/v2/courses/subject_catalog_number_schedule.md
+++ b/v2/courses/subject_catalog_number_schedule.md
@@ -52,6 +52,7 @@ GET /courses/{subject}/{catalog_number}/schedule.{format}
 
 ### Notes
 
+- By default, only schedules for the current term will be returned if the [`term` parameter](#parameters) is not given
 - Any value can be `null`
 
 


### PR DESCRIPTION
I was afraid that the API didn't have data for the Winter 2014 term while I was exploring this method, and was almost about to open an issue when I read the docs again more thoroughly. :)
