### PR TITLE
Response Section bugfix

### DIFF
--- a/v2/codes/terms.md
+++ b/v2/codes/terms.md
@@ -115,7 +115,7 @@ GET /codes/terms.{format}
     <td><b>Value Description</b></td>
   </tr>
   <tr>
-    <td><b>term</b></td>
+    <td><b>abbreviation</b></td>
     <td>string</td>
     <td>Term</td>
   </tr>


### PR DESCRIPTION
Changed the field name of "term" inside of Response to "abbreviation", as the API currently does NOT return a field named term.