### PR TITLE
Changed formating of GET examples

### DIFF
--- a/v2/resources/tutors.1481.json
+++ b/v2/resources/tutors.1481.json
@@ -1,6 +1,6 @@
 {
    "method_id":1481,
-   "method_url":"/v2/resources/tutors.{format}",
+   "method_url":"/resources/tutors.{format}",
    "method_name":"List of student tutors available",
    "service_id":229,
    "service_name":"resources",

--- a/v2/resources/tutors.md
+++ b/v2/resources/tutors.md
@@ -1,7 +1,7 @@
 # List of student tutors available
 
 ```
-GET /v2/resources/tutors.{format}
+GET /resources/tutors.{format}
 ```
 
 ## Description
@@ -63,7 +63,7 @@ GET /v2/resources/tutors.{format}
 ## Parameters
 
 ```
-GET /v2/resources/tutors.{format}
+GET /resources/tutors.{format}
 ```
 
 <table>
@@ -96,7 +96,7 @@ GET /v2/resources/tutors.{format}
 ## Examples
 
 ```
-GET /v2/resources/tutors.{format}
+GET /resources/tutors.{format}
 ```
 
 - **https://api.uwaterloo.ca/v2/resources/tutors.json**


### PR DESCRIPTION
Changed "GET /v2/resources/tutors.{format}" to "GET /resources/tutors.{format}" in order to match formatting of all other end point documentation.