### PR TITLE
Changed building_id in example to be a string

### DIFF
--- a/v2/buildings/building_acronym.md
+++ b/v2/buildings/building_acronym.md
@@ -184,7 +184,7 @@ Any value can be `null`
     }
   },
   "data":{
-    "building_id":23,
+    "building_id":"23",
     "building_code":"MHR",
     "building_name":"Minota Hagey Residence",
     "alternate_names":[


### PR DESCRIPTION
The API actually returns

```json

},
  "data":{
    "building_id":"23",
    "building_code":"MHR",
    "building_name":"Minota Hagey Residence",
    "alternate_names":[
      "Velocity"
    ],
    "latitude":43.46579535,
    "longitude":-80.54275113,
    "building_sections":[
      
    ],
    "building_outline":[
      
    ]
  }

```

Unsure if other files need to be changed or not. 