### PR TITLE
Fixed incorrect type 

### DIFF
--- a/v2/courses/subject_catalog_number_prerequisites.1181.json
+++ b/v2/courses/subject_catalog_number_prerequisites.1181.json
@@ -79,7 +79,7 @@
       {
          "field":"prerequisites",
          "description":"Raw listing of course prerequisites",
-         "type":"number"
+         "type":"string"
       },
       {
          "field":"prerequisites_parsed",

--- a/v2/courses/subject_catalog_number_prerequisites.md
+++ b/v2/courses/subject_catalog_number_prerequisites.md
@@ -149,7 +149,7 @@ GET /courses/{subject}/{catalog_number}/prerequisites.{format}
   </tr>
   <tr>
     <td><b>prerequisites</b></td>
-    <td>number</td>
+    <td>string</td>
     <td>Raw listing of course prerequisites</td>
   </tr>
   <tr>


### PR DESCRIPTION
Changed number to string. Not sure if it is possible for it to return a number, but in the example it is a string and calling MATH 136 returns a string. 