### PR TITLE
/courses not .courses

### DIFF
--- a/v2/terms/term_courses.md
+++ b/v2/terms/term_courses.md
@@ -64,7 +64,7 @@ GET /terms/{term_id}.courses.{format}
 ## Parameters
 
 ```
-GET /terms/{term_id}.courses.{format}
+GET /terms/{term_id}/courses.{format}
 ```
 
 <table>
@@ -97,7 +97,7 @@ GET /terms/{term_id}.courses.{format}
 ## Examples
 
 ```
-GET /terms/{term_id}.courses.{format}
+GET /terms/{term_id}/courses.{format}
 ```
 
 - **https://api.uwaterloo.ca/v2/terms/1161/courses.json**


### PR DESCRIPTION
API call will not work with GET /terms/{term_id}.courses.{format} but rather GET /terms/{term_id}/courses.{format}