### PR TITLE
Add WatSwift into Client Libraries list

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ The data is returned in `json` and `xml` where the output format can be specifie
 * [UWAPI.go](https://github.com/SaintDako/uwAPI.go) (Golang)
 * [UW-Open-Data-API](https://github.com/zainh96/UW-Open-Data-API) (Java)
 * [UWaterloo-API](https://github.com/sanchitgera/node-uwaterloo-api) (NodeJS)
+* [WatSwift](https://github.com/meteochu/WatSwift) (Swift)
 
 ## Endpoints
 


### PR DESCRIPTION
Recently, I wrote an OpenData API client in Swift, and thought it'd be cool if it was added into the Client Libraries list. My client library, named `WatSwift`, supports all the listed endpoints in this endpoint, and is currently available for anyone writing for iOS and macOS. (Linux support requires the Swift Team to complete native `URLSession` implementation, which is currently unavailable.)

Thanks!