### PR TITLE
Typos

### DIFF
--- a/v2/courses/subject_catalog_number_schedule.md
+++ b/v2/courses/subject_catalog_number_schedule.md
@@ -382,7 +382,7 @@ Any value can be `null`
       ],
       "classes":[
         {
-          "dates":{
+          "date":{
             "start_time":"16:00",
             "end_time":"17:20",
             "weekdays":"TTh",

--- a/v2/terms/term_courses.md
+++ b/v2/terms/term_courses.md
@@ -1,7 +1,7 @@
 # Course listings by term
 
 ```
-GET /terms/{term_id}.courses.{format}
+GET /terms/{term_id}/courses.{format}
 ```
 
 ## Description


### PR DESCRIPTION
it should be 'GET /terms/{term_id}/courses.{format}' not 'GET /terms/{term_id}.courses.{format}'